### PR TITLE
Update prepare.py: fix logic to set IDF_GITHUB_ASSETS

### DIFF
--- a/tools/prepare.py
+++ b/tools/prepare.py
@@ -128,9 +128,9 @@ def copy_idf_tools_py(root):
 
 def install_target(target):
     if get_country_code() != "China":
-        os.environ["IDF_GITHUB_ASSETS"] = "dl.espressif.cn/github_assets"
-    else:
         os.environ["IDF_GITHUB_ASSETS"] = "dl.espressif.com/github_assets"
+    else:
+        os.environ["IDF_GITHUB_ASSETS"] = "dl.espressif.cn/github_assets"
 
     idf_path = os.environ["IDF_PATH"]
     


### PR DESCRIPTION
It got it backwards: it routes non-china traffic to CN host and China traffic to .com host.

This bug makes downloading from especially outside of China much slower.