### PR TITLE
Update tkl_pin.c - added handling of all Tuya GPIO pin output modes 

### DIFF
--- a/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_pin.c
+++ b/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_pin.c
@@ -157,9 +157,6 @@ OPERATE_RET tkl_gpio_init(TUYA_GPIO_NUM_E pin_id, const TUYA_GPIO_BASE_CFG_T *cf
                          __func__, cfg->mode, gpio_num);
                 break;
         }
-        
-        // Set initial output level
-        gpio_set_level(gpio_num, cfg->level);
     } 
     else {
         // Invalid direction
@@ -191,6 +188,11 @@ OPERATE_RET tkl_gpio_init(TUYA_GPIO_NUM_E pin_id, const TUYA_GPIO_BASE_CFG_T *cf
             default:
                 return OPRT_COM_ERROR;
         }
+    }
+
+    // Set initial output level ONLY AFTER pin is properly configured
+    if (cfg->direct == TUYA_GPIO_OUTPUT) {
+        gpio_set_level(gpio_num, cfg->level);
     }
 
     // Log successful configuration for debugging

--- a/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_pin.c
+++ b/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_pin.c
@@ -231,29 +231,6 @@ OPERATE_RET tkl_gpio_read(TUYA_GPIO_NUM_E pin_id, TUYA_GPIO_LEVEL_E *level)
 }
 
 /**
- * @brief Toggle a GPIO pin (optional, not in original but useful)
- * 
- * @param pin_id Tuya GPIO pin identifier
- * @return OPERATE_RET OPRT_OK on success, error code on failure
- */
-OPERATE_RET tkl_gpio_toggle(TUYA_GPIO_NUM_E pin_id)
-{
-    int gpio_num;
-    TUYA_GPIO_LEVEL_E current_level;
-
-    PIN_DEV_CHECK_ERROR_RETURN(pin_id, OPRT_INVALID_PARM);
-    gpio_num = pinmap[pin_id].gpio;
-    
-    // Read current level
-    current_level = gpio_get_level(gpio_num);
-    
-    // Toggle to opposite level
-    gpio_set_level(gpio_num, !current_level);
-    
-    return OPRT_OK;
-}
-
-/**
  * @brief gpio irq init
  * NOTE: call this API will not enable interrupt
  * 


### PR DESCRIPTION
See also https://github.com/tuya/TuyaOpen-esp32/issues/57

 ## Problem:
 `tkl_gpio_init()` didn't handle all Tuya GPIO output modes.


## Changes Made:

1. **Fixed `tkl_gpio_init()`**: Now properly handles all Tuya GPIO modes:
   - Input modes (0-3): `PULLUP`, `PULLDOWN`, `HIGH_IMPEDANCE`, `FLOATING`
   - Output modes (4-6): `PUSH_PULL`, `OPENDRAIN`, `OPENDRAIN_PULLUP`

2. **Used Modern `gpio_config()` API**: Replaced deprecated `gpio_set_direction()` + `gpio_set_pull_mode()` with unified `gpio_config()`

3. **Added Proper Error Mapping**: Maps ESP32 error codes to appropriate Tuya error codes

4. **Added Debug Logging**: Better error messages and debug output

5. **Fixed ISR Service Handling**: Checks `ESP_ERR_INVALID_STATE` when ISR service is already installed

~~6. **Added `tkl_gpio_toggle()`**: Optional but useful helper function~~ (removed, non-standard)

7. **Fixed `tkl_gpio_deinit()`**: Properly handles ISR handler removal and error checking

## Compatibility:
- Maintains full backward compatibility with existing Tuya GPIO API
- Uses modern ESP32 GPIO API for reliability
- Handles all ESP32 variants (ESP32, ESP32-C3, ESP32-C6, ESP32-S2, ESP32-S3)
- Properly maps Tuya's GPIO modes to ESP32's GPIO modes

This fix will resolve any GPIO output initialization errors for both push-pull outputs and open-drain outputs.

UPDATE: 
- The gpio_set_level() is moved after configuration done to prevent conflicts

