### PR TITLE
feat(tkl): add multi-chip support for UART1 pins and PWM GPIO mapping

### DIFF
--- a/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_pinmux.c
+++ b/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_pinmux.c
@@ -41,6 +41,8 @@ typedef struct{
 extern void __tkl_i2c_set_scl_pin(TUYA_I2C_NUM_E port, const TUYA_PIN_NAME_E scl_pin);
 extern void __tkl_i2c_set_sda_pin(TUYA_I2C_NUM_E port, const TUYA_PIN_NAME_E sda_pin);
 extern void __tkl_pwm_set_pin(TUYA_GPIO_NUM_E pin, TUYA_PWM_NUM_E channel);
+extern void __tkl_uart1_set_txd_pin(TUYA_PIN_NAME_E pin);
+extern void __tkl_uart1_set_rxd_pin(TUYA_PIN_NAME_E pin);
 /**
  * @brief tuya io pinmux func
  *
@@ -90,6 +92,13 @@ OPERATE_RET tkl_io_pinmux_config(TUYA_PIN_NAME_E pin, TUYA_PIN_FUNC_E pin_func)
             __tkl_i2c_set_sda_pin(TUYA_I2C_NUM_5, pin);
             break;
 #endif
+        case TUYA_UART1_TX:
+            __tkl_uart1_set_txd_pin(pin);
+            break;
+        case TUYA_UART1_RX:
+            __tkl_uart1_set_rxd_pin(pin);
+            break;
+
         case TUYA_PWM0 :
             __tkl_pwm_set_pin(pin, TUYA_PWM_NUM_0);
             break;

--- a/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_pwm.c
+++ b/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_pwm.c
@@ -41,12 +41,32 @@ typedef struct {
 } SR_PWM_GPIO_T;
 
 static SR_PWM_GPIO_T sg_pwm_gpio_map[] = {
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+    /* C3: GPIO range 0-21; GPIO12-17 are SPI flash, GPIO18-19 are USB-JTAG */
+    {TUYA_IO_PIN_18, LEDC_CHANNEL_0},
+    {TUYA_IO_PIN_19, LEDC_CHANNEL_1},
+    {TUYA_IO_PIN_3,  LEDC_CHANNEL_2},
+    {TUYA_IO_PIN_4,  LEDC_CHANNEL_3},
+    {TUYA_IO_PIN_5,  LEDC_CHANNEL_4},
+    {TUYA_IO_PIN_6,  LEDC_CHANNEL_5},
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    /* S3: GPIO22-25 are NC; GPIO26-37 are SPI flash/PSRAM, not for general use */
+    {TUYA_IO_PIN_18, LEDC_CHANNEL_0},
+    {TUYA_IO_PIN_19, LEDC_CHANNEL_1},
+    {TUYA_IO_PIN_38, LEDC_CHANNEL_2},
+    {TUYA_IO_PIN_39, LEDC_CHANNEL_3},
+    {TUYA_IO_PIN_40, LEDC_CHANNEL_4},
+    {TUYA_IO_PIN_41, LEDC_CHANNEL_5},
+#else
+    /* ESP32 classic: GPIO34-39 are input-only; GPIO18/19/22/23/25/26 are all output-capable */
+    /* ESP32-C6: GPIO range 0-30; GPIO18/19/22/23/25/26 are all valid */
     {TUYA_IO_PIN_18, LEDC_CHANNEL_0},
     {TUYA_IO_PIN_19, LEDC_CHANNEL_1},
     {TUYA_IO_PIN_22, LEDC_CHANNEL_2},
     {TUYA_IO_PIN_23, LEDC_CHANNEL_3},
     {TUYA_IO_PIN_25, LEDC_CHANNEL_4},
     {TUYA_IO_PIN_26, LEDC_CHANNEL_5},
+#endif
 };
 
 #if 0

--- a/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_uart.c
+++ b/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_uart.c
@@ -249,10 +249,28 @@ int tkl_uart_read(TUYA_UART_NUM_E port_id, void *buff, uint16_t len)
 #define TKL_UART_NUM_0_CTS  (UART_PIN_NO_CHANGE)
 
 
-#define TKL_UART_NUM_1_TXD  (GPIO_NUM_17)
-#define TKL_UART_NUM_1_RXD  (GPIO_NUM_18)
+#if defined(CONFIG_IDF_TARGET_ESP32)
+static int sg_uart1_txd = GPIO_NUM_10;  /* IO_MUX native default */
+static int sg_uart1_rxd = GPIO_NUM_9;
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+static int sg_uart1_txd = GPIO_NUM_6;   /* avoids conflict with UART0 default RX GPIO17 */
+static int sg_uart1_rxd = GPIO_NUM_7;
+#else
+static int sg_uart1_txd = GPIO_NUM_17;
+static int sg_uart1_rxd = GPIO_NUM_18;
+#endif
 #define TKL_UART_NUM_1_RTS  (UART_PIN_NO_CHANGE)
 #define TKL_UART_NUM_1_CTS  (UART_PIN_NO_CHANGE)
+
+void __tkl_uart1_set_txd_pin(TUYA_PIN_NAME_E pin)
+{
+    sg_uart1_txd = (int)pin;
+}
+
+void __tkl_uart1_set_rxd_pin(TUYA_PIN_NAME_E pin)
+{
+    sg_uart1_rxd = (int)pin;
+}
 
 TaskHandle_t tkl_uart_thread = NULL;
 TUYA_UART_IRQ_CB uart_rx_cb[MAX_UART_NUM];
@@ -378,8 +396,8 @@ OPERATE_RET tkl_uart_init(TUYA_UART_NUM_E port_id, TUYA_UART_BASE_CFG_T *cfg)
 #endif
 
     if (UART_NUM_1 == uart_num) {
-        uart_txd = TKL_UART_NUM_1_TXD;
-        uart_rxd = TKL_UART_NUM_1_RXD;
+        uart_txd = sg_uart1_txd;
+        uart_rxd = sg_uart1_rxd;
         uart_cts = TKL_UART_NUM_1_CTS;
         uart_rts = TKL_UART_NUM_1_RTS;
     } else {


### PR DESCRIPTION
- tkl_uart.c: replace hard-coded UART1 TX/RX pins with chip-specific defaults (ESP32/C6/others) and expose __tkl_uart1_set_txd/rxd_pin() setters for runtime reconfiguration via pinmux
- tkl_pinmux.c: add TUYA_UART1_TX/RX cases to tkl_io_pinmux_config() to route pin assignments through the new UART1 setters
- tkl_pwm.c: add #if guards to select correct default PWM GPIO map for ESP32-C3, ESP32-S3, and ESP32 classic / C6