### PR TITLE
fix(build): remove managed component LVGL include paths from platform…

### DIFF
--- a/platform_config.cmake
+++ b/platform_config.cmake
@@ -14,8 +14,6 @@ set(PLATFORM_PUBINC_2
     ${IDF_PATH}/components/esp_rom/include
     ${IDF_PATH}/components/soc/${TOS_PROJECT_CHIP}/include
     ${PLATFORM_PATH}/tuya_open_sdk/build/config
-    ${PLATFORM_PATH}/tuya_open_sdk/managed_components/lvgl__lvgl/src
-    ${PLATFORM_PATH}/tuya_open_sdk/managed_components/lvgl__lvgl
     ${PLATFORM_PATH}/tuya_open_sdk/tuyaos_adapter/include/utilities/include/
     ${BOARD_INC}
 )


### PR DESCRIPTION
… config

The managed_components/lvgl__lvgl headers were taking priority over TuyaOpen's own LVGL v9 headers during libtuyaapp.a compilation. This caused undefined reference errors (lv_color_white, lv_screen_active, etc.) because the managed component declares them as regular functions while TuyaOpen's LVGL v9 defines them as static inline.