### PR TITLE
fix(esp32p4): wrap hci_rx_handler to resolve symbol conflict with esp…

### DIFF
--- a/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
+++ b/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
@@ -114,3 +114,7 @@ idf_component_register(SRCS "${SOURCES}"
                     INCLUDE_DIRS "${include_dirs}"
                     REQUIRES ${adapter_requires}
                     )
+
+if(CONFIG_IDF_TARGET_ESP32P4)
+    target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=hci_rx_handler")
+endif()

--- a/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_bt.c
+++ b/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_bt.c
@@ -388,9 +388,9 @@ OPERATE_RET tkl_hci_deinit(void)
     return OPRT_OK;
 }
 
-/* Rx path: strong override of the upstream WEAK stub. Called by ESP-Hosted
- * transport when an ESP_HCI_IF packet arrives from the C6. */
-int hci_rx_handler(interface_buffer_handle_t *buf_handle)
+/* Rx path: wraps the esp_hosted stub via --wrap linker flag. Called by
+ * ESP-Hosted transport when an ESP_HCI_IF packet arrives from the C6. */
+int __wrap_hci_rx_handler(interface_buffer_handle_t *buf_handle)
 {
     if (NULL == buf_handle || NULL == buf_handle->payload || buf_handle->payload_len < 1) {
         return 0;


### PR DESCRIPTION
…_hosted

The esp_hosted component defines hci_rx_handler in hci_stub_drv.c and links with --whole-archive, conflicting with the TuyaOpen implementation in tkl_bt.c. Use --wrap linker flag to cleanly redirect calls to the TuyaOpen handler without requiring muldefs.