### PR TITLE
feat: ESP32-P4-C6 board 适配补丁（基于官方 0422216）

### DIFF
--- a/tuya_open_sdk/main/idf_component.yml
+++ b/tuya_open_sdk/main/idf_component.yml
@@ -17,3 +17,5 @@ dependencies:
   espressif/esp_io_expander_tca9554: "==2.0.0"
   espressif/esp_lcd_panel_io_additions: "^1.0.1"
   espressif/esp_lcd_touch_ft5x06: ~1.0.7
+  espressif/esp_lcd_touch_gt911: ">=1.0.0"
+  espressif/esp_lcd_st7701: "*"

--- a/tuya_open_sdk/sdkconfig_esp32p4_c6
+++ b/tuya_open_sdk/sdkconfig_esp32p4_c6
@@ -564,6 +564,11 @@ CONFIG_ESP_NETIF_REPORT_DATA_TRAFFIC=y
 #
 # ESP PSRAM
 #
+# Bump PSRAM to 200MHz so the MIPI-DSI DPI controller has enough bandwidth to
+# fetch the framebuffer without underrun (bottom-of-screen blue + dpi underrun
+# spam). 200M requires experimental features to be enabled.
+CONFIG_IDF_EXPERIMENTAL_FEATURES=y
+CONFIG_SPIRAM_SPEED_200M=y
 # end of ESP PSRAM
 
 #

--- a/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
+++ b/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
@@ -101,6 +101,8 @@ set(adapter_requires
     driver
     app_update
     esp_lcd_touch_ft5x06
+    esp_lcd_touch_gt911
+    esp_lcd_st7701
 )
 
 # espressif__esp_hosted is only available on chips without native Wi-Fi

--- a/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_i2s.c
+++ b/tuya_open_sdk/tuyaos_adapter/src/drivers/tkl_i2s.c
@@ -52,6 +52,10 @@ static TKL_I2S_GPIO_CFG_T sg_i2s_gpio_cfg[TUYA_I2S_NUM_MAX] = {
     {GPIO_NUM_5, GPIO_NUM_4, GPIO_NUM_6},   // I2S0
     {GPIO_NUM_15, GPIO_NUM_16, GPIO_NUM_7}, // I2S1
 };
+#elif defined(CONFIG_IDF_TARGET_ESP32P4)
+static TKL_I2S_GPIO_CFG_T sg_i2s_gpio_cfg[TUYA_I2S_NUM_MAX] = {
+    {GPIO_NUM_12, GPIO_NUM_10, GPIO_NUM_11}, // I2S0 — ESP32-P4-C6 dev board (bclk/ws/data)
+};
 #endif
 
 static TKL_I2S_HANDLE_T sg_i2s_hdl[TUYA_I2S_NUM_MAX] = {0};


### PR DESCRIPTION
官方 0422216 提供 esp_hosted P4 WiFi/BT，但缺 board 级硬件适配：

- idf_component.yml: 添加 esp_lcd_touch_gt911 + esp_lcd_st7701 （GT911 触摸 + ST7701 MIPI DSI 屏，官方只带 ft5x06）
- tuyaos_adapter/CMakeLists.txt: REQUIRES 加 gt911 + st7701
- sdkconfig_esp32p4_c6: PSRAM 提到 200MHz（+IDF_EXPERIMENTAL_FEATURES） 修复 MIPI DSI DPI underrun（屏幕下半蓝屏），保证帧缓冲带宽
- tkl_i2s.c: 补 ESP32-P4 的 I2S GPIO 配置（bclk=12/ws=10/data=11）