### PR TITLE
feat(esp32p4): MIPI-CSI camera (OV5647 / esp_video) platform support

### DIFF
--- a/tuya_open_sdk/main/idf_component.yml
+++ b/tuya_open_sdk/main/idf_component.yml
@@ -19,3 +19,9 @@ dependencies:
   espressif/esp_lcd_touch_ft5x06: ~1.0.7
   espressif/esp_lcd_touch_gt911: ">=1.0.0"
   espressif/esp_lcd_st7701: "*"
+  # MIPI-CSI camera (ESP32-P4 only). esp_video pulls in esp_cam_sensor with
+  # OV5647 etc. Only needed on P4; native-WiFi chips don't have MIPI-CSI.
+  espressif/esp_video:
+    version: "0.8.*"
+    rules:
+      - if: "target == esp32p4"

--- a/tuya_open_sdk/sdkconfig_esp32p4_c6
+++ b/tuya_open_sdk/sdkconfig_esp32p4_c6
@@ -1112,7 +1112,13 @@ CONFIG_USB_OTG_SUPPORTED=y
 #
 # Virtual file system
 #
-# CONFIG_VFS_SUPPORT_IO is not set
+# VFS POSIX IO is required by esp_video: it registers the MIPI-CSI camera as
+# /dev/video0 and the V4L2 interface uses open()/ioctl()/close() through the VFS
+# layer. TuyaOpen disables it by default (it uses its own TKL file APIs), which
+# made esp_video_init fail with "Failed to register video VFS dev name=video0".
+CONFIG_VFS_SUPPORT_IO=y
+CONFIG_VFS_SUPPORT_DIR=y
+CONFIG_VFS_SUPPORT_SELECT=y
 # end of Virtual file system
 
 #
@@ -1325,3 +1331,13 @@ CONFIG_ESP32_PTHREAD_TASK_CORE_DEFAULT=-1
 CONFIG_ESP32_PTHREAD_TASK_NAME_DEFAULT="pthread"
 CONFIG_SPI_FLASH_WRITING_DANGEROUS_REGIONS_ABORTS=y
 # End of deprecated options
+
+#
+# MIPI-CSI Camera (ESP32-P4 + OV5647)
+# Provided by the esp_video / esp_cam_sensor components (P4 only).
+# OV5647 outputs RAW8 800x1280@50fps; the P4 ISP pipeline converts RAW -> RGB565/YUV422.
+#
+CONFIG_CAMERA_OV5647=y
+CONFIG_CAMERA_OV5647_MIPI_RAW8_800x1280_50FPS=y
+CONFIG_ESP_VIDEO_ENABLE_ISP_PIPELINE_CONTROLLER=y
+# end of MIPI-CSI Camera

--- a/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
+++ b/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
@@ -108,8 +108,15 @@ set(adapter_requires
 # espressif__esp_hosted is only available on chips without native Wi-Fi
 # (currently ESP32-P4 paired with a C6 co-processor). On S3/C3/ESP32 this
 # component is not pulled in by idf_component.yml so we must not require it.
-if(CONFIG_IDF_TARGET_ESP32P4)
+# Use IDF_TARGET (always defined during component processing) rather than
+# CONFIG_IDF_TARGET_ESP32P4, which is not reliably set as a CMake variable at
+# this point — the old guard never fired, so these REQUIRES were silently
+# dropped (WiFi still worked because esp_wifi_remote pulls esp_hosted in
+# transitively, but the esp_video include path was missing).
+if(IDF_TARGET STREQUAL "esp32p4")
     list(APPEND adapter_requires espressif__esp_hosted)
+    # esp_video provides the V4L2 MIPI-CSI camera interface (P4 only).
+    list(APPEND adapter_requires espressif__esp_video espressif__esp_cam_sensor)
 endif()
 
 idf_component_register(SRCS "${SOURCES}"

--- a/tuya_open_sdk/tuyaos_adapter/src/system/tkl_system.c
+++ b/tuya_open_sdk/tuyaos_adapter/src/system/tkl_system.c
@@ -17,7 +17,32 @@
 
 #include "esp_random.h"
 #include "esp_system.h"
+
+/* Critical-section spinlock. tal_system_enter/exit_critical() map to these and
+ * are pulled in by components that protect shared lists/queues (e.g. the camera
+ * TDL layer). The ESP32 adapter previously declared but never implemented them. */
+static portMUX_TYPE s_tkl_critical_mux = portMUX_INITIALIZER_UNLOCKED;
 // --- END: user defines and implements ---
+
+uint32_t tkl_system_enter_critical(void)
+{
+    if (xPortInIsrContext()) {
+        taskENTER_CRITICAL_ISR(&s_tkl_critical_mux);
+    } else {
+        taskENTER_CRITICAL(&s_tkl_critical_mux);
+    }
+    return 0;
+}
+
+void tkl_system_exit_critical(uint32_t irq_mask)
+{
+    (void)irq_mask;
+    if (xPortInIsrContext()) {
+        taskEXIT_CRITICAL_ISR(&s_tkl_critical_mux);
+    } else {
+        taskEXIT_CRITICAL(&s_tkl_critical_mux);
+    }
+}
 
 /**
 * @brief system reset


### PR DESCRIPTION
- idf_component.yml: add espressif/esp_video 0.8.* (target esp32p4), pulls esp_cam_sensor (OV5647)
- sdkconfig_esp32p4_c6: enable OV5647 + ISP pipeline controller; enable VFS_SUPPORT_IO/DIR/SELECT (esp_video registers /dev/video0 and uses open/ioctl/close via VFS; the SDK default VFS-off made esp_video_init fail with "Failed to register video VFS dev name=video0")
- tuyaos_adapter/CMakeLists.txt: guard P4-only REQUIRES with IDF_TARGET (CONFIG_IDF_TARGET_ESP32P4 is not reliably set at component-eval time, so the appended REQUIRES were silently dropped); add esp_video / esp_cam_sensor so board camera code can include the V4L2 headers
- tkl_system.c: implement tkl_system_enter/exit_critical (FreeRTOS portMUX, ISR-aware); declared-but-unimplemented on ESP32, pulled in by the camera TDL list/queue layer