### PR TITLE
fix(esp32): gate esp_lcd_st7701 to esp32p4

### DIFF
--- a/tuya_open_sdk/main/idf_component.yml
+++ b/tuya_open_sdk/main/idf_component.yml
@@ -18,7 +18,12 @@ dependencies:
   espressif/esp_lcd_panel_io_additions: "^1.0.1"
   espressif/esp_lcd_touch_ft5x06: ~1.0.7
   espressif/esp_lcd_touch_gt911: ">=1.0.0"
-  espressif/esp_lcd_st7701: "*"
+  # ST7701 MIPI-DSI panel driver — ESP32-P4 only (MIPI-DSI is P4-exclusive).
+  # Other targets (esp32, esp32s3, ...) have no matching version, so gate it.
+  espressif/esp_lcd_st7701:
+    version: ">2.0.0"
+    rules:
+      - if: "target == esp32p4"
   # MIPI-CSI camera (ESP32-P4 only). esp_video pulls in esp_cam_sensor with
   # OV5647 etc. Only needed on P4; native-WiFi chips don't have MIPI-CSI.
   espressif/esp_video:

--- a/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
+++ b/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
@@ -104,7 +104,6 @@ set(adapter_requires
     app_update
     esp_lcd_touch_ft5x06
     esp_lcd_touch_gt911
-    esp_lcd_st7701
 )
 
 # espressif__esp_hosted is only available on chips without native Wi-Fi
@@ -119,6 +118,10 @@ if(IDF_TARGET STREQUAL "esp32p4")
     list(APPEND adapter_requires espressif__esp_hosted)
     # esp_video provides the V4L2 MIPI-CSI camera interface (P4 only).
     list(APPEND adapter_requires espressif__esp_video espressif__esp_cam_sensor)
+    # esp_lcd_st7701 is a MIPI-DSI panel driver (P4 only). Matches the
+    # target == esp32p4 gate in main/idf_component.yml — on other targets the
+    # component has no matching version and must not be required.
+    list(APPEND adapter_requires esp_lcd_st7701)
 endif()
 
 # PPA (Pixel-Processing Accelerator) backs tkl_dma2d on the ESP32-P4. Use


### PR DESCRIPTION
esp_lcd_st7701 is a MIPI-DSI panel driver and only has versions for the ESP32-P4 (MIPI-DSI is P4-exclusive). It was declared unconditionally in main/idf_component.yml and required unconditionally in the adapter, so non-P4 builds (esp32, esp32s3, ...) failed dependency solving with "no versions of espressif/esp_lcd_st7701 match".

Gate it to target == esp32p4 in both the manifest (with a >2.0.0 version constraint for the MIPI API) and the adapter REQUIRES list, matching how esp_video / esp_hosted are already handled.