### PR TITLE
feat(esp32): glob adapter include dirs + support app-private components

### DIFF
--- a/tuya_open_sdk/CMakeLists.txt
+++ b/tuya_open_sdk/CMakeLists.txt
@@ -5,6 +5,14 @@
 cmake_minimum_required(VERSION 3.16)
 
 set(EXTRA_COMPONENT_DIRS tuyaos_adapter)
+# Generic drop-in port: dirs listed in $TUYAOS_EXTRA_COMPONENT_DIRS (space-separated) become
+# IDF component ROOTS — every subdir under each is auto-registered as a component. Lets an app
+# add project-private, esp-idf-visible components with NO edit to this file. Set by the TuyaOpen
+# CLI (tools/cli_command/cli_build.py) to <app>/components when that dir exists.
+if(NOT "$ENV{TUYAOS_EXTRA_COMPONENT_DIRS}" STREQUAL "")
+    string(REPLACE " " ";" _tuyaos_extra_comp_dirs "$ENV{TUYAOS_EXTRA_COMPONENT_DIRS}")
+    list(APPEND EXTRA_COMPONENT_DIRS ${_tuyaos_extra_comp_dirs})
+endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(tuya_open_sdk)

--- a/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
+++ b/tuya_open_sdk/tuyaos_adapter/CMakeLists.txt
@@ -41,31 +41,23 @@ else()
     list(APPEND SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/drivers/tkl_bt.c")
 endif()
 
-set(include_dirs
-    "include/adc"
-    "include/dma2d"
-    "include/bluetooth"
-    "include/flash"
-    "include/i2c"
-    "include/i2s"
-    "include/gpio"
-    "include/hci"
-    "include/init/include"
-    "include/network"
-    "include/pinmux"
-    "include/pwm"
-    "include/rtc"
-    "include/spi"
-    "include/system"
-    "include/timer"
-    "include/uart"
-    "include/watchdog"
-    "include/wifi"
-    "include/utilities/include"
-    "include/vad"
-    "include/kws"
-    "include/media"
-    )
+# Expose ALL header dirs under include/ (mirrors the T5AI / T3 adapters) so any
+# REQUIRES-tuyaos_adapter consumer resolves every public tkl/tal header — no
+# hand-maintained subset to drift out of date (the old curated list omitted
+# include/security and include/lwip, so tal_api.h failed on tkl_hash.h).
+macro(FIND_INCLUDE_DIR result curdir)
+    file(GLOB_RECURSE children "${curdir}/*.h")
+    set(dirlist "")
+    foreach(child ${children})
+        string(REGEX REPLACE "(.*)/.*" "\\1" DIR_NAME ${child})
+        if((IS_DIRECTORY ${DIR_NAME}) AND (NOT (${DIR_NAME} IN_LIST dirlist)))
+            list(APPEND dirlist ${DIR_NAME})
+        endif()
+    endforeach()
+    set(${result} ${dirlist})
+endmacro()
+
+FIND_INCLUDE_DIR(include_dirs "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 if(NOT "$ENV{TUYAOS_HEADER_DIR}" STREQUAL "")
 


### PR DESCRIPTION
tuyaos_adapter/CMakeLists.txt: replace the hand-maintained include_dirs subset with a recursive glob of every dir under include/ (mirrors the T5AI/T3 adapters). The curated list omitted include/security and include/lwip, so any REQUIRES-tuyaos_adapter consumer pulling tal_api.h failed on tkl_hash.h. Globbing keeps the public tkl/tal header set from drifting out of date.

tuya_open_sdk/CMakeLists.txt: append dirs listed in the env var TUYAOS_EXTRA_COMPONENT_DIRS to EXTRA_COMPONENT_DIRS, so an app can ship project-private, esp-idf-visible components with no edit to this file. Set by the TuyaOpen CLI to <app>/components when that dir exists.