### PR TITLE
fix(audio_afe): use PSRAM ring buffer when available

### DIFF
--- a/tuya_open_sdk/tuyaos_adapter/src/audio/audio_afe.c
+++ b/tuya_open_sdk/tuyaos_adapter/src/audio/audio_afe.c
@@ -193,7 +193,11 @@ OPERATE_RET audio_afe_processor_init(void)
     }
 
     // Initialize ring buffer
+#if defined(TUYA_PSARM_SUPPORT)
+    rt = tuya_ring_buff_create(FEED_RB_SIZE, OVERFLOW_PSRAM_STOP_TYPE, &sg_afe_proce.rb);
+#else
     rt = tuya_ring_buff_create(FEED_RB_SIZE, OVERFLOW_STOP_TYPE, &sg_afe_proce.rb);
+#endif
     if (OPRT_OK != rt) {
         ESP_LOGE(TAG, "Failed to create ring buffer");
         return rt;


### PR DESCRIPTION
AFE processor's 8KB feed ring buffer was allocated from internal SRAM via OVERFLOW_STOP_TYPE, but after WakeNet/NS/VAD initialization consumes most internal SRAM, the allocation fails (OPRT_MALLOC_FAILED=-3).

Use OVERFLOW_PSRAM_STOP_TYPE when TUYA_PSARM_SUPPORT is defined, which allocates from PSRAM via tkl_system_psram_malloc(). This is consistent with ai_audio_input.c, tuya_ai_input.c, and other audio modules.