### PR TITLE
fix(deps): pin esp-sr to 2.4.6 to avoid MALLOC_CAP_SIMD error on ESP-IDF 5.4

### DIFF
--- a/tuya_open_sdk/main/idf_component.yml
+++ b/tuya_open_sdk/main/idf_component.yml
@@ -12,7 +12,7 @@ dependencies:
     rules:
       - if: "target == esp32p4"
   waveshare/esp_lcd_sh8601: "1.0.2"
-  espressif/esp-sr: ^2.0.0
+  espressif/esp-sr: "==2.4.6"
   espressif/esp_codec_dev: "~1.3.2"
   espressif/esp_io_expander_tca9554: "==2.0.0"
   espressif/esp_lcd_panel_io_additions: "^1.0.1"


### PR DESCRIPTION
## Description

Pin `espressif/esp-sr` to `==2.4.6` in `idf_component.yml`.

### Root Cause
Recent upstream updates to `esp-sr` / `espressif/esp-dl` introduced `MALLOC_CAP_SIMD` in `dl_image_process.cpp`, which is undefined in ESP-IDF 5.4 headers and causes compilation failure across ESP32 targets.

Pinning `esp-sr` to the known stable `2.4.6` release avoids pulling in the incompatible `esp-dl` version on ESP-IDF 5.4.
