### PR TITLE
fix(deps): pin exact versions for all components in idf_component.yml

### DIFF
--- a/tuya_open_sdk/main/idf_component.yml
+++ b/tuya_open_sdk/main/idf_component.yml
@@ -17,11 +17,11 @@ dependencies:
   espressif/esp_io_expander_tca9554: "==2.0.0"
   espressif/esp_lcd_panel_io_additions: "^1.0.1"
   espressif/esp_lcd_touch_ft5x06: ~1.0.7
-  espressif/esp_lcd_touch_gt911: ">=1.0.0"
+  espressif/esp_lcd_touch_gt911: "^1.2.0"
   # ST7701 MIPI-DSI panel driver — ESP32-P4 only (MIPI-DSI is P4-exclusive).
   # Other targets (esp32, esp32s3, ...) have no matching version, so gate it.
   espressif/esp_lcd_st7701:
-    version: ">2.0.0"
+    version: "^2.0.0"
     rules:
       - if: "target == esp32p4"
   # MIPI-CSI camera (ESP32-P4 only). esp_video pulls in esp_cam_sensor with
@@ -32,6 +32,6 @@ dependencies:
       - if: "target == esp32p4"
   # DVP camera (ESP32 / ESP32-S3).
   espressif/esp32-camera:
-    version: ">=2.0.9"
+    version: "^2.0.9"
     rules:
       - if: "target in [esp32, esp32s3]"

--- a/tuya_open_sdk/main/idf_component.yml
+++ b/tuya_open_sdk/main/idf_component.yml
@@ -4,34 +4,34 @@ dependencies:
   # Pulling them in on chips with native Wi-Fi (S3, C3, ...) causes link
   # conflicts with libnet80211 (multiple definition of wifi_deinit etc.).
   espressif/esp_wifi_remote:
-    version: "0.14.*"
+    version: "==0.14.5"
     rules:
       - if: "target == esp32p4"
   espressif/esp_hosted:
-    version: "1.4.*"
+    version: "==1.4.7"
     rules:
       - if: "target == esp32p4"
-  waveshare/esp_lcd_sh8601: "1.0.2"
+  waveshare/esp_lcd_sh8601: "==1.0.2"
   espressif/esp-sr: "==2.4.6"
-  espressif/esp_codec_dev: "~1.3.2"
+  espressif/esp_codec_dev: "==1.3.6"
   espressif/esp_io_expander_tca9554: "==2.0.0"
-  espressif/esp_lcd_panel_io_additions: "^1.0.1"
-  espressif/esp_lcd_touch_ft5x06: ~1.0.7
-  espressif/esp_lcd_touch_gt911: "^1.2.0"
+  espressif/esp_lcd_panel_io_additions: "==1.0.1"
+  espressif/esp_lcd_touch_ft5x06: "==1.0.7"
+  espressif/esp_lcd_touch_gt911: "==1.2.0"
   # ST7701 MIPI-DSI panel driver — ESP32-P4 only (MIPI-DSI is P4-exclusive).
   # Other targets (esp32, esp32s3, ...) have no matching version, so gate it.
   espressif/esp_lcd_st7701:
-    version: "^2.0.0"
+    version: "==2.0.2"
     rules:
       - if: "target == esp32p4"
   # MIPI-CSI camera (ESP32-P4 only). esp_video pulls in esp_cam_sensor with
   # OV5647 etc. Only needed on P4; native-WiFi chips don't have MIPI-CSI.
   espressif/esp_video:
-    version: "0.8.*"
+    version: "==0.8.0"
     rules:
       - if: "target == esp32p4"
   # DVP camera (ESP32 / ESP32-S3).
   espressif/esp32-camera:
-    version: "^2.0.9"
+    version: "==2.1.7"
     rules:
       - if: "target in [esp32, esp32s3]"


### PR DESCRIPTION
## Description

Pin exact versions (`==`) for all direct component dependencies in `tuya_open_sdk/main/idf_component.yml` based on tested, known-working builds across ESP32 targets (including P4, S3, C3, C6, ESP32):

- `espressif/esp_wifi_remote`: `==0.14.5`
- `espressif/esp_hosted`: `==1.4.7`
- `waveshare/esp_lcd_sh8601`: `==1.0.2`
- `espressif/esp-sr`: `==2.4.6`
- `espressif/esp_codec_dev`: `==1.3.6`
- `espressif/esp_io_expander_tca9554`: `==2.0.0`
- `espressif/esp_lcd_panel_io_additions`: `==1.0.1`
- `espressif/esp_lcd_touch_ft5x06`: `==1.0.7`
- `espressif/esp_lcd_touch_gt911`: `==1.2.0`
- `espressif/esp_lcd_st7701`: `==2.0.2`
- `espressif/esp_video`: `==0.8.0`
- `espressif/esp32-camera`: `==2.1.7`

### Rationale
Completely locks down component versions to prevent IDF Component Manager from fetching breaking upstream releases on clean CI / multi-target builds.
